### PR TITLE
Rename the ActorSystem fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,3 @@
 ## v0.0.1 - 2018-12-07
 
 Initial release of scala-messaging!
-
-## v0.0.1 - 2018-12-07
-
-Empty entry to start the release notes.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Rename the `withActorSystem` method used internally for scala-messaging tests.

--- a/src/test/scala/uk/ac/wellcome/messaging/fixtures/Akka.scala
+++ b/src/test/scala/uk/ac/wellcome/messaging/fixtures/Akka.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import org.scalatest.concurrent.Eventually
 
 private[messaging] trait Akka extends Eventually {
-  private[messaging] def withActorSystem[R] = fixture[ActorSystem, R](
+  private[messaging] def withMessagingActorSystem[R] = fixture[ActorSystem, R](
     create = ActorSystem(),
     destroy = eventually { _.terminate() }
   )

--- a/src/test/scala/uk/ac/wellcome/messaging/fixtures/Messaging.scala
+++ b/src/test/scala/uk/ac/wellcome/messaging/fixtures/Messaging.scala
@@ -88,7 +88,7 @@ trait Messaging
   def withMessageStreamFixtures[T, R](
     testWith: TestWith[(MessageStream[T], QueuePair, MetricsSender), R]
   )(implicit objectStore: ObjectStore[T]): R =
-    withActorSystem { implicit actorSystem =>
+    withMessagingActorSystem { implicit actorSystem =>
       withLocalSqsQueueAndDlq {
         case queuePair @ QueuePair(queue, _) =>
           withMockMetricSender { metricsSender =>

--- a/src/test/scala/uk/ac/wellcome/messaging/message/MessagingIntegrationTest.scala
+++ b/src/test/scala/uk/ac/wellcome/messaging/message/MessagingIntegrationTest.scala
@@ -80,7 +80,7 @@ class MessagingIntegrationTest
 
   def withLocalStackMessageStreamFixtures[R](
     testWith: TestWith[(Queue, MessageStream[ExampleObject]), R]): R =
-    withActorSystem { implicit actorSystem =>
+    withMessagingActorSystem { implicit actorSystem =>
       withMetricsSender(actorSystem) { metricsSender =>
         withLocalStackSqsQueue { queue =>
           withMessageStream[ExampleObject, R](queue, metricsSender) {

--- a/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
+++ b/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
@@ -235,7 +235,7 @@ class SQSStreamTest
   def withSQSStreamFixtures[R](
     testWith: TestWith[(SQSStream[ExampleObject], QueuePair, MetricsSender), R])
     : R =
-    withActorSystem { implicit actorSystem =>
+    withMessagingActorSystem { implicit actorSystem =>
       withLocalSqsQueueAndDlq {
         case queuePair @ QueuePair(queue, _) =>
           withMockMetricSender { metricsSender =>


### PR DESCRIPTION
Right now it's causing a bunch of issues in the platform. We should really just move this into its own common lib.