### PR TITLE
Prepare Workers for locking

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: major 
+
+Adds an intermediate AkkaWorker type and further generalises Worker behaviour

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
@@ -14,16 +14,15 @@ import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 
 import scala.concurrent.Future
 
-class AlpakkaSQSWorker[Work, Summary,
-  MonitoringClientImpl <: MonitoringClient](
+class AlpakkaSQSWorker[Work, Summary, MonitoringClientImpl <: MonitoringClient](
   config: AlpakkaSQSWorkerConfig
 )(
   val doWork: Work => Future[Result[Summary]]
 )(implicit
-    val mc: MonitoringClientImpl,
-    val as: ActorSystem,
-    val wd: Decoder[Work],
-    sc: AmazonSQSAsync,
+  val mc: MonitoringClientImpl,
+  val as: ActorSystem,
+  val wd: Decoder[Work],
+  sc: AmazonSQSAsync,
 ) extends AkkaWorker[SQSMessage, Work, Summary, MessageAction]
     with SnsSqsTransform[Work]
     with Logging {
@@ -50,11 +49,11 @@ object AlpakkaSQSWorker {
   def apply[Work, Summary](config: AlpakkaSQSWorkerConfig)(
     process: Work => Future[Result[Summary]]
   )(implicit
-      mc: MonitoringClient,
-      sc: AmazonSQSAsync,
-      as: ActorSystem,
-      wd: Decoder[Work]
-  ) = new AlpakkaSQSWorker[Work, Summary, MonitoringClient](
-    config
-  )(process)
+    mc: MonitoringClient,
+    sc: AmazonSQSAsync,
+    as: ActorSystem,
+    wd: Decoder[Work]) =
+    new AlpakkaSQSWorker[Work, Summary, MonitoringClient](
+      config
+    )(process)
 }

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/sqsworker/alpakka/AlpakkaSQSWorker.scala
@@ -1,96 +1,60 @@
 package uk.ac.wellcome.messaging.sqsworker.alpakka
 
 import akka.actor.ActorSystem
+import akka.stream.alpakka.sqs
 import akka.stream.alpakka.sqs.MessageAction
 import akka.stream.alpakka.sqs.scaladsl.{SqsAckSink, SqsSource}
-import akka.stream.scaladsl.{Keep, Sink, Source}
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
-import akka.{Done, NotUsed}
 import com.amazonaws.services.sqs.AmazonSQSAsync
-import com.amazonaws.services.sqs.model.Message
+import com.amazonaws.services.sqs.model.{Message => SQSMessage}
 import grizzled.slf4j.Logging
 import io.circe.Decoder
-import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.worker._
 import uk.ac.wellcome.messaging.worker.models._
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 
 import scala.concurrent.Future
 
+class AlpakkaSQSWorker[Work, Summary,
+  MonitoringClientImpl <: MonitoringClient](
+  config: AlpakkaSQSWorkerConfig
+)(
+  val doWork: Work => Future[Result[Summary]]
+)(implicit
+    val mc: MonitoringClientImpl,
+    val as: ActorSystem,
+    val wd: Decoder[Work],
+    sc: AmazonSQSAsync,
+) extends AkkaWorker[SQSMessage, Work, Summary, MessageAction]
+    with SnsSqsTransform[Work]
+    with Logging {
+
+  type SQSAction = SQSMessage => (SQSMessage, sqs.MessageAction)
+
+  val parallelism: Int = config.parallelism
+  val source = SqsSource(config.queueUrl)
+  val sink = SqsAckSink(config.queueUrl)
+
+  private val makeVisibleAction = MessageAction
+    .changeMessageVisibility(visibilityTimeout = 0)
+
+  val retryAction: SQSAction = (message: SQSMessage) =>
+    (message, makeVisibleAction)
+
+  val completedAction: SQSAction = (message: SQSMessage) =>
+    (message, MessageAction.delete)
+
+  override val namespace: String = config.namespace
+}
+
 object AlpakkaSQSWorker {
   def apply[Work, Summary](config: AlpakkaSQSWorkerConfig)(
     process: Work => Future[Result[Summary]]
-  )(implicit monitoringClient: MonitoringClient,
-    sqsClient: AmazonSQSAsync,
-    decoder: Decoder[Work],
-    actorSystem: ActorSystem) = {
-
-    new AlpakkaSQSWorker[Work, Summary](config)(process)
-
-  }
+  )(implicit
+      mc: MonitoringClient,
+      sc: AmazonSQSAsync,
+      as: ActorSystem,
+      wd: Decoder[Work]
+  ) = new AlpakkaSQSWorker[Work, Summary, MonitoringClient](
+    config
+  )(process)
 }
-
-class AlpakkaSQSWorker[Work, Summary](
-  config: AlpakkaSQSWorkerConfig
-)(
-  messageProcess: Work => Future[Result[Summary]]
-)(implicit monitoringClient: MonitoringClient,
-  sqsClient: AmazonSQSAsync,
-  decoder: Decoder[Work],
-  actorSystem: ActorSystem)
-    extends Worker[Message, Work, Summary]
-    with Logging {
-
-  implicit val _ec = actorSystem.dispatcher
-  override val namespace: String = config.namespace
-
-  override protected def processMessage(work: Work) =
-    messageProcess(work)
-
-  override protected def transform(message: Message): Future[Work] = {
-
-    val maybeWork = for {
-      notification <- fromJson[NotificationMessage](message.getBody)
-      work <- fromJson[Work](notification.body)
-    } yield work
-
-    Future.fromTry(maybeWork)
-  }
-
-  private val source =
-    SqsSource(config.queueUrl)
-  private val sink: Sink[(Message, MessageAction), Future[Done]] =
-    SqsAckSink(config.queueUrl)
-
-  private val processedSource: Source[(Message, MessageAction), NotUsed] =
-    source
-      .mapAsyncUnordered(config.parallelism) { message =>
-        work(message)
-      }
-      .map {
-        case WorkCompletion(message, response, _) =>
-          response.asInstanceOf[Action] match {
-            case _: Retry =>
-              (message, MessageAction.changeMessageVisibility(0))
-            case _: Completed => (message, MessageAction.delete)
-          }
-      }
-
-  def start: Future[Unit] = {
-    implicit val _ = ActorMaterializer(
-      ActorMaterializerSettings(actorSystem)
-    )
-
-    processedSource
-      .toMat(sink)(Keep.right)
-      .run()
-      .map(_ => ())
-  }
-}
-
-case class AlpakkaSQSWorkerConfig(
-  namespace: String,
-  queueUrl: String,
-  parallelism: Int = 1
-)

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/sqsworker/alpakka/AlpakkaSQSWorkerConfig.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/sqsworker/alpakka/AlpakkaSQSWorkerConfig.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.messaging.sqsworker.alpakka
 
 case class AlpakkaSQSWorkerConfig(
-                                   namespace: String,
-                                   queueUrl: String,
-                                   parallelism: Int = 1
-                                 )
+  namespace: String,
+  queueUrl: String,
+  parallelism: Int = 1
+)

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/sqsworker/alpakka/AlpakkaSQSWorkerConfig.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/sqsworker/alpakka/AlpakkaSQSWorkerConfig.scala
@@ -1,0 +1,7 @@
+package uk.ac.wellcome.messaging.sqsworker.alpakka
+
+case class AlpakkaSQSWorkerConfig(
+                                   namespace: String,
+                                   queueUrl: String,
+                                   parallelism: Int = 1
+                                 )

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/worker/AkkaWorker.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/worker/AkkaWorker.scala
@@ -7,9 +7,8 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 
 import scala.concurrent.Future
 
-
 trait AkkaWorker[Message, Work, Summary, Action]
-  extends Worker[Message, Work, Summary, Action] {
+    extends Worker[Message, Work, Summary, Action] {
 
   implicit val as: ActorSystem
   implicit val am: ActorMaterializer =
@@ -34,8 +33,8 @@ trait AkkaWorker[Message, Work, Summary, Action]
   private def completionSource(parallelism: Int): ProcessedSource =
     source.mapAsyncUnordered(parallelism)(processMessage)
 
-  def start: Future[Done] = completionSource(parallelism)
+  def start: Future[Done] =
+    completionSource(parallelism)
       .toMat(sink)(Keep.right)
       .run()
 }
-

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/worker/AkkaWorker.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/worker/AkkaWorker.scala
@@ -1,0 +1,41 @@
+package uk.ac.wellcome.messaging.worker
+
+import akka.{Done, NotUsed}
+import akka.actor.ActorSystem
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
+import akka.stream.scaladsl.{Keep, Sink, Source}
+
+import scala.concurrent.Future
+
+
+trait AkkaWorker[Message, Work, Summary, Action]
+  extends Worker[Message, Work, Summary, Action] {
+
+  implicit val as: ActorSystem
+  implicit val am: ActorMaterializer =
+    ActorMaterializer(
+      ActorMaterializerSettings(as)
+    )
+  implicit val ec = as.dispatcher
+
+  type MessageSource = Source[Message, NotUsed]
+  type MessageSink = Sink[(Message, Action), Future[Done]]
+
+  type ProcessedSource = Source[(Message, Action), NotUsed]
+
+  protected val parallelism: Int
+
+  protected val source: MessageSource
+  protected val sink: MessageSink
+
+  protected val retryAction: MessageAction
+  protected val completedAction: MessageAction
+
+  private def completionSource(parallelism: Int): ProcessedSource =
+    source.mapAsyncUnordered(parallelism)(processMessage)
+
+  def start: Future[Done] = completionSource(parallelism)
+      .toMat(sink)(Keep.right)
+      .run()
+}
+

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/worker/MessageTransform.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/worker/MessageTransform.scala
@@ -1,0 +1,31 @@
+package uk.ac.wellcome.messaging.worker
+
+import com.amazonaws.services.sqs.model.{Message => SQSMessage}
+import io.circe.Decoder
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.sns.NotificationMessage
+
+import scala.concurrent.Future
+
+sealed trait MessageTransform[Message, Work] {
+  val transform: Message => Future[Work]
+}
+
+trait SnsSqsTransform[Work]
+  extends MessageTransform[SQSMessage, Work] {
+
+  type SQSTransform = SQSMessage => Future[Work]
+
+  implicit val nd = implicitly[Decoder[NotificationMessage]]
+  implicit val wd: Decoder[Work]
+
+  val transform: SQSTransform = (message: SQSMessage) =>
+    Future.fromTry(
+      for {
+        notification <-
+          fromJson[NotificationMessage](message.getBody)
+        work <-
+          fromJson[Work](notification.body)
+      } yield work
+    )
+}

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/worker/MessageTransform.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/worker/MessageTransform.scala
@@ -11,8 +11,7 @@ sealed trait MessageTransform[Message, Work] {
   val transform: Message => Future[Work]
 }
 
-trait SnsSqsTransform[Work]
-  extends MessageTransform[SQSMessage, Work] {
+trait SnsSqsTransform[Work] extends MessageTransform[SQSMessage, Work] {
 
   type SQSTransform = SQSMessage => Future[Work]
 
@@ -22,10 +21,8 @@ trait SnsSqsTransform[Work]
   val transform: SQSTransform = (message: SQSMessage) =>
     Future.fromTry(
       for {
-        notification <-
-          fromJson[NotificationMessage](message.getBody)
-        work <-
-          fromJson[Work](notification.body)
+        notification <- fromJson[NotificationMessage](message.getBody)
+        work <- fromJson[Work](notification.body)
       } yield work
-    )
+  )
 }

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/worker/Worker.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/worker/Worker.scala
@@ -2,14 +2,14 @@ package uk.ac.wellcome.messaging.worker
 
 import java.time.Instant
 
-
-
-import uk.ac.wellcome.messaging.worker.models.{Completed, WorkCompletion, Retry}
+import uk.ac.wellcome.messaging.worker.models.{Completed, Retry, WorkCompletion}
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
-import uk.ac.wellcome.messaging.worker.steps.{MessageProcessor, MonitoringProcessor}
+import uk.ac.wellcome.messaging.worker.steps.{
+  MessageProcessor,
+  MonitoringProcessor
+}
 
 import scala.concurrent.{ExecutionContext, Future}
-
 
 trait Worker[Message, Work, Summary, Action]
     extends MessageProcessor[Message, Work, Summary]
@@ -35,7 +35,8 @@ trait Worker[Message, Work, Summary, Action]
     for {
       summary <- process(message)
       monitor <- record(startTime, summary)
-    } yield WorkCompletion(
+    } yield
+      WorkCompletion(
         message,
         summary,
         monitor
@@ -46,7 +47,7 @@ trait Worker[Message, Work, Summary, Action]
     done match {
       case WorkCompletion(message, response, _) =>
         response.asInstanceOf[Action] match {
-          case _: Retry => retryAction(message)
+          case _: Retry     => retryAction(message)
           case _: Completed => completedAction(message)
         }
     }

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/worker/Worker.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/worker/Worker.scala
@@ -2,35 +2,53 @@ package uk.ac.wellcome.messaging.worker
 
 import java.time.Instant
 
-import uk.ac.wellcome.messaging.worker.models.WorkCompletion
+
+
+import uk.ac.wellcome.messaging.worker.models.{Completed, WorkCompletion, Retry}
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
-import uk.ac.wellcome.messaging.worker.steps.{
-  MessageProcessor,
-  MonitoringProcessor
-}
+import uk.ac.wellcome.messaging.worker.steps.{MessageProcessor, MonitoringProcessor}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait Worker[Message, Work, Summary]
+
+trait Worker[Message, Work, Summary, Action]
     extends MessageProcessor[Message, Work, Summary]
     with MonitoringProcessor {
 
-  protected def work[ProcessMonitoringClient <: MonitoringClient](
-    message: Message)(
-    implicit monitoringClient: ProcessMonitoringClient,
-    ec: ExecutionContext): Future[WorkCompletion[Message, Summary]] = {
+  type Processed = Future[(Message, Action)]
 
+  implicit val ec: ExecutionContext
+  implicit val mc: MonitoringClient
+
+  type Completion = WorkCompletion[Message, Summary]
+  type MessageAction = Message => (Message, Action)
+
+  protected val retryAction: MessageAction
+  protected val completedAction: MessageAction
+
+  protected def processMessage(message: Message): Processed =
+    work(message).map(completion)
+
+  private def work(message: Message): Future[Completion] = {
     val startTime = Instant.now
 
     for {
       summary <- process(message)
       monitor <- record(startTime, summary)
-
-    } yield
-      WorkCompletion(
+    } yield WorkCompletion(
         message,
         summary,
         monitor
       )
   }
+
+  private def completion(done: Completion) =
+    done match {
+      case WorkCompletion(message, response, _) =>
+        response.asInstanceOf[Action] match {
+          case _: Retry => retryAction(message)
+          case _: Completed => completedAction(message)
+        }
+    }
+
 }

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/worker/WorkerTest.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/worker/WorkerTest.scala
@@ -85,15 +85,17 @@ class WorkerTest
               monClientFail
             )
 
-            val process = worker.work(message)
+            val process = worker.processMessage(message)
 
             whenReady(process) { _ =>
-              worker.calledCount shouldBe calledCount
+              worker.callCounter.calledCount shouldBe calledCount
 
-              assertMetricCount(worker.metrics, metricName, metricCount, empty)
+              assertMetricCount(
+                worker.mc, metricName, metricCount, empty
+              )
 
               assertMetricDurations(
-                worker.metrics,
+                worker.mc,
                 "namespace/Duration",
                 metricCount,
                 empty)

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/worker/steps/MessageProcessorTest.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/worker/steps/MessageProcessorTest.scala
@@ -33,7 +33,7 @@ class MessageProcessorTest
       forAll(processResults) {
         (testProcess, messageToWorkShouldFail, checkType) =>
           val processor =
-            new MyMessageProcessor(testProcess, messageToWorkShouldFail)
+            new MyMessageProcessor(createResult(testProcess, new CallCounter), messageToWorkShouldFail)
           val futureResult = processor.process(message)
 
           whenReady(futureResult)(checkType)

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/worker/steps/MonitoringProcessorTest.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/worker/steps/MonitoringProcessorTest.scala
@@ -58,23 +58,29 @@ class MonitoringProcessorTest
     it("performs the correct monitoring functions") {
       forAll(postProcessActions) {
         (result, metricName, count, noMetric, monClientFail, checkType) =>
+
           val processor =
-            new MyMonitoringProcessor(result, false, monClientFail)
+            new MyMonitoringProcessor(
+              toActionShouldFail = false,
+              monitoringClientShouldFail = monClientFail
+            )
 
-          val metrics = processor.monitoringClient
-          val futureResult = processor.record(result)
+          val metrics = processor.mc
 
-          whenReady(futureResult) { action =>
-            checkType(action)
+            val recorded = processor.record(result)
 
-            assertMetricCount(metrics, metricName, count, noMetric)
-            assertMetricDurations(
-              metrics,
-              "namespace/Duration",
-              count,
-              noMetric)
+            whenReady(recorded) { action =>
+              checkType(action)
+
+              assertMetricCount(metrics, metricName, count, noMetric)
+              assertMetricDurations(
+                metrics,
+                "namespace/Duration",
+                count,
+                noMetric)
+            }
           }
-      }
+
     }
   }
 }


### PR DESCRIPTION
- Move some functionality into Worker so that it is generalised 
- Adds an `AkkaWorker` between `Worker` and `AlpakkaSQSWorker`