### PR TITLE
Use MemoryMetrics everywhere in scala-messaging

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Remove Mockito from the SQS trait and use MemoryMetrics everywhere, and bump the version of scala-monitoring.

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
@@ -1,19 +1,20 @@
 package uk.ac.wellcome.messaging.sqs
 
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings, Supervision}
 import akka.stream.alpakka.sqs.MessageAction
 import akka.stream.alpakka.sqs.MessageAction.Delete
 import akka.stream.alpakka.sqs.scaladsl.{SqsAckSink, SqsSource}
 import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings, Supervision}
 import akka.{Done, NotUsed}
+import com.amazonaws.services.cloudwatch.model.StandardUnit
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.model.Message
 import grizzled.slf4j.Logging
 import io.circe.Decoder
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.exceptions.JsonDecodingError
-import uk.ac.wellcome.monitoring.MetricsSender
+import uk.ac.wellcome.monitoring.Metrics
 
 import scala.concurrent.Future
 
@@ -35,7 +36,7 @@ import scala.concurrent.Future
 class SQSStream[T](
   sqsClient: AmazonSQSAsync,
   sqsConfig: SQSConfig,
-  metricsSender: MetricsSender)(implicit val actorSystem: ActorSystem)
+  metricsSender: Metrics[Future, StandardUnit])(implicit val actorSystem: ActorSystem)
     extends Logging {
 
   implicit val dispatcher = actorSystem.dispatcher

--- a/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
+++ b/messaging/src/main/scala/uk/ac/wellcome/messaging/sqs/SQSStream.scala
@@ -33,10 +33,10 @@ import scala.concurrent.Future
 //        process = processMessage
 //      )
 //
-class SQSStream[T](
-  sqsClient: AmazonSQSAsync,
-  sqsConfig: SQSConfig,
-  metricsSender: Metrics[Future, StandardUnit])(implicit val actorSystem: ActorSystem)
+class SQSStream[T](sqsClient: AmazonSQSAsync,
+                   sqsConfig: SQSConfig,
+                   metricsSender: Metrics[Future, StandardUnit])(
+  implicit val actorSystem: ActorSystem)
     extends Logging {
 
   implicit val dispatcher = actorSystem.dispatcher

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.messaging.sqsworker.alpakka
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
@@ -15,7 +16,8 @@ class AlpakkaSQSWorkerTest
     with AlpakkaSQSWorkerFixtures
     with ScalaFutures
     with IntegrationPatience
-    with Eventually {
+    with Eventually
+    with Akka {
 
   val namespace = "AlpakkaSQSWorkerTest"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object WellcomeDependencies {
   private lazy val versions = new {
     val fixtures = "1.0.0"
     val json = "1.1.1"
-    val monitoring = "2.2.0"
+    val monitoring = "2.3.0"
     val typesafe = "1.0.0"
   }
 
@@ -41,7 +41,6 @@ object Dependencies {
     val akkaStreamAlpakka = "0.20"
     val circe = "0.9.0"
     val circeYaml = "0.8.0"
-    val mockito = "1.9.5"
     val scalatest = "3.0.1"
     val logback = "1.2.3"
   }
@@ -61,8 +60,7 @@ object Dependencies {
   )
 
   val testDependencies = Seq(
-    "org.scalatest" %% "scalatest" % versions.scalatest % Test,
-    "org.mockito" % "mockito-core" % versions.mockito % Test
+    "org.scalatest" %% "scalatest" % versions.scalatest % Test
   )
 
   val libraryDependencies: Seq[ModuleID] = Seq(


### PR DESCRIPTION
For wellcometrust/platform#3660, and because conflicting Mockito versions are breaking some catalogue tests