### PR TITLE
Clean up the SQS fixtures

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,6 +26,7 @@ This release changes how some of the SQS helpers work.
 
 *   The `SQS.Queue` case class now includes the `visibilityTimeout`.
 
-*   The following helpers have been made private, because they weren't in use in the catalogue or storage-service repos:
+*   The following helpers have been made private or removed, because they weren't in use in the catalogue or storage-service repos:
 
     -   `waitVisibilityTimeoutExipiry()`
+    -   `assertQueuePairSizes()`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,31 @@
+RELEASE_TYPE: minor
+
+This release changes how some of the SQS helpers work.
+
+*   `withLocalSqsQueueAndDlq` and `withLocalSqsQueueAndDlqAndTimeout` are both renamed to `withLocalSqsQueuePair()`, which takes an optional `visibilityTimeout` argument.
+
+    The DLQ name will also be the name of the main queue suffixed with `-dlq` for easier debugging.
+
+*   `withLocalSqsQueue` now takes an optional `visibilityTimeout` argument.
+
+    If you are using it without arguments, e.g.:
+
+    ```scala
+    withLocalSqsQueue { queue =>
+      // do stuff with queue
+    }
+    ```
+
+    you need to add empty parentheses:
+
+    ```scala
+    withLocalSqsQueue() { queue =>
+      // do stuff with queue
+    }
+    ```
+
+*   The `SQS.Queue` case class now includes the `visibilityTimeout`.
+
+*   The following helpers have been made private, because they weren't in use in the catalogue or storage-service repos:
+
+    -   `waitVisibilityTimeoutExipiry()`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,5 +28,6 @@ This release changes how some of the SQS helpers work.
 
 *   The following helpers have been made private or removed, because they weren't in use in the catalogue or storage-service repos:
 
-    -   `waitVisibilityTimeoutExipiry()`
+    -   `assertQueueNotEmpty()`
     -   `assertQueuePairSizes()`
+    -   `waitVisibilityTimeoutExipiry()`

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/fixtures/SQS.scala
@@ -261,13 +261,6 @@ trait SQS extends Matchers with Logging {
     )
   }
 
-  def assertQueuePairSizes(queue: QueuePair,
-                           qSize: Int,
-                           dlqSize: Int): Assertion = {
-    assertQueueHasSize(queue = queue.queue, size = qSize)
-    assertQueueHasSize(queue = queue.dlq, size = dlqSize)
-  }
-
   def assertQueueHasSize(queue: Queue, size: Int): Assertion = {
     waitVisibilityTimeoutExpiry(queue)
 

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/fixtures/SQS.scala
@@ -20,7 +20,7 @@ import scala.concurrent.Future
 import scala.util.Random
 
 object SQS {
-  case class Queue(url: String, arn: String) {
+  case class Queue(url: String, arn: String, visibilityTimeout: Int) {
     override def toString = s"SQS.Queue(url = $url, name = $name)"
     def name: String = url.split("/").toList.last
   }
@@ -60,49 +60,16 @@ trait SQS extends Matchers with Logging {
       secretKey = sqsSecretKey
     )
 
-  private def withLocalSqsQueue[R](client: SqsClient): Fixture[Queue, R] =
-    fixture[Queue, R](
-      create = {
-        val queueName: String = Random.alphanumeric take 10 mkString
-        val response = client.createQueue {
-          builder: CreateQueueRequest.Builder =>
-            builder.queueName(queueName)
-        }
-        val arn = client
-          .getQueueAttributes { builder: GetQueueAttributesRequest.Builder =>
-            builder
-              .queueUrl(response.queueUrl())
-              .attributeNames(QueueAttributeName.QUEUE_ARN)
-          }
-          .attributes()
-          .get(QueueAttributeName.QUEUE_ARN)
-        val queue = Queue(response.queueUrl(), arn)
-        client
-          .setQueueAttributes { builder: SetQueueAttributesRequest.Builder =>
-            builder
-              .queueUrl(queue.url)
-              .attributes(
-                Map(QueueAttributeName.VISIBILITY_TIMEOUT -> "1").asJava)
-          }
-        queue
-      },
-      destroy = { queue =>
-        client.purgeQueue { builder: PurgeQueueRequest.Builder =>
-          builder.queueUrl(queue.url)
-        }
-        client.deleteQueue { builder: DeleteQueueRequest.Builder =>
-          builder.queueUrl(queue.url)
-        }
+  private def setQueueAttribute(queueUrl: String,
+                                attributeName: QueueAttributeName,
+                                attributeValue: String): SetQueueAttributesResponse =
+    sqsClient
+      .setQueueAttributes { builder: SetQueueAttributesRequest.Builder =>
+        builder
+          .queueUrl(queueUrl)
+          .attributes(
+            Map(attributeName -> attributeValue).asJava)
       }
-    )
-
-  def withLocalSqsQueue[R](testWith: TestWith[Queue, R]): R =
-    withLocalSqsQueue(sqsClient) { queue =>
-      testWith(queue)
-    }
-
-  def withLocalSqsQueueAndDlq[R](testWith: TestWith[QueuePair, R]): R =
-    withLocalSqsQueueAndDlqAndTimeout(visibilityTimeout = 1)(testWith)
 
   private def getQueueAttribute(queueUrl: String,
                                 attributeName: QueueAttributeName): String =
@@ -119,27 +86,62 @@ trait SQS extends Matchers with Logging {
                         attributeName: QueueAttributeName): String =
     getQueueAttribute(queueUrl = queue.url, attributeName = attributeName)
 
-  def withLocalSqsQueueAndDlqAndTimeout[R](visibilityTimeout: Int)(
-    testWith: TestWith[QueuePair, R]): R =
-    withLocalSqsQueue { dlq =>
-      val queueName: String = Random.alphanumeric take 10 mkString
-      val response = sqsClient.createQueue {
-        builder: CreateQueueRequest.Builder =>
-          builder
-            .queueName(queueName)
-            .attributes(Map(
-              QueueAttributeName.REDRIVE_POLICY -> s"""{"maxReceiveCount":"3", "deadLetterTargetArn":"${dlq.arn}"}""",
-              QueueAttributeName.VISIBILITY_TIMEOUT -> s"$visibilityTimeout"
-            ).asJava)
-      }
-      val arn = getQueueAttribute(
-        queueUrl = response.queueUrl(),
-        attributeName = QueueAttributeName.QUEUE_ARN
-      )
+  def withLocalSqsQueue[R](
+    client: SqsClient = sqsClient,
+    queueName: String = Random.alphanumeric take 10 mkString,
+    visibilityTimeout: Int = 1
+  ): Fixture[Queue, R] =
+    fixture[Queue, R](
+      create = {
+        val response = client.createQueue {
+          builder: CreateQueueRequest.Builder =>
+            builder.queueName(queueName)
+        }
 
-      val queue = Queue(response.queueUrl(), arn)
-      testWith(QueuePair(queue, dlq))
+        val arn = getQueueAttribute(
+          queueUrl = response.queueUrl(),
+          attributeName = QueueAttributeName.QUEUE_ARN
+        )
+
+        val queue = Queue(
+          url = response.queueUrl(),
+          arn = arn,
+          visibilityTimeout = visibilityTimeout
+        )
+
+        setQueueAttribute(
+          queueUrl = queue.url,
+          attributeName = QueueAttributeName.VISIBILITY_TIMEOUT,
+          attributeValue = visibilityTimeout.toString
+        )
+
+        queue
+      },
+      destroy = { queue =>
+        client.purgeQueue { builder: PurgeQueueRequest.Builder =>
+          builder.queueUrl(queue.url)
+        }
+        client.deleteQueue { builder: DeleteQueueRequest.Builder =>
+          builder.queueUrl(queue.url)
+        }
+      }
+    )
+
+  def withLocalSqsQueuePair[R](visibilityTimeout: Int = 1)(testWith: TestWith[QueuePair, R]): R = {
+    val queueName = Random.alphanumeric take 10 mkString
+
+    withLocalSqsQueue(sqsClient, queueName = s"$queueName-dlq") { dlq =>
+      withLocalSqsQueue(sqsClient, queueName = queueName, visibilityTimeout = visibilityTimeout) { queue =>
+        setQueueAttribute(
+          queueUrl = queue.url,
+          attributeName = QueueAttributeName.REDRIVE_POLICY,
+          attributeValue = s"""{"maxReceiveCount":"3", "deadLetterTargetArn":"${dlq.arn}"}"""
+        )
+
+        testWith(QueuePair(queue, dlq))
+      }
     }
+  }
 
   val localStackSqsClient: SqsClient = SQSClientFactory.createSyncClient(
     region = "localhost",
@@ -237,7 +239,7 @@ trait SQS extends Matchers with Logging {
   }
 
   def assertQueueEmpty(queue: Queue): Assertion = {
-    waitVisibilityTimeoutExipiry()
+    waitVisibilityTimeoutExpiry(queue)
 
     val messages = getMessages(queue)
 
@@ -249,7 +251,7 @@ trait SQS extends Matchers with Logging {
   }
 
   def assertQueueNotEmpty(queue: Queue): Assertion = {
-    waitVisibilityTimeoutExipiry()
+    waitVisibilityTimeoutExpiry(queue)
 
     val messages = getMessages(queue)
 
@@ -267,7 +269,7 @@ trait SQS extends Matchers with Logging {
   }
 
   def assertQueueHasSize(queue: Queue, size: Int): Assertion = {
-    waitVisibilityTimeoutExipiry()
+    waitVisibilityTimeoutExpiry(queue)
 
     val messages = getMessages(queue)
     val messagesSize = messages.size
@@ -278,11 +280,12 @@ trait SQS extends Matchers with Logging {
     )
   }
 
-  def waitVisibilityTimeoutExipiry(): Unit =
-    // The visibility timeout is set to 1 second for test queues.
-    // Wait for slightly longer than that to make sure that messages
+  private def waitVisibilityTimeoutExpiry(queue: Queue): Unit = {
+    // Wait slightly longer than the visibility timeout to ensure that messages
     // that fail processing become visible again before asserting.
-    Thread.sleep(1500)
+    val millisecondsToWait = queue.visibilityTimeout * 1500
+    Thread.sleep(millisecondsToWait)
+  }
 
   def getMessages(queue: Queue): Seq[Message] =
     sqsClient

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/fixtures/SQS.scala
@@ -60,15 +60,15 @@ trait SQS extends Matchers with Logging {
       secretKey = sqsSecretKey
     )
 
-  private def setQueueAttribute(queueUrl: String,
-                                attributeName: QueueAttributeName,
-                                attributeValue: String): SetQueueAttributesResponse =
+  private def setQueueAttribute(
+    queueUrl: String,
+    attributeName: QueueAttributeName,
+    attributeValue: String): SetQueueAttributesResponse =
     sqsClient
       .setQueueAttributes { builder: SetQueueAttributesRequest.Builder =>
         builder
           .queueUrl(queueUrl)
-          .attributes(
-            Map(attributeName -> attributeValue).asJava)
+          .attributes(Map(attributeName -> attributeValue).asJava)
       }
 
   private def getQueueAttribute(queueUrl: String,
@@ -127,15 +127,20 @@ trait SQS extends Matchers with Logging {
       }
     )
 
-  def withLocalSqsQueuePair[R](visibilityTimeout: Int = 1)(testWith: TestWith[QueuePair, R]): R = {
+  def withLocalSqsQueuePair[R](visibilityTimeout: Int = 1)(
+    testWith: TestWith[QueuePair, R]): R = {
     val queueName = Random.alphanumeric take 10 mkString
 
     withLocalSqsQueue(sqsClient, queueName = s"$queueName-dlq") { dlq =>
-      withLocalSqsQueue(sqsClient, queueName = queueName, visibilityTimeout = visibilityTimeout) { queue =>
+      withLocalSqsQueue(
+        sqsClient,
+        queueName = queueName,
+        visibilityTimeout = visibilityTimeout) { queue =>
         setQueueAttribute(
           queueUrl = queue.url,
           attributeName = QueueAttributeName.REDRIVE_POLICY,
-          attributeValue = s"""{"maxReceiveCount":"3", "deadLetterTargetArn":"${dlq.arn}"}"""
+          attributeValue =
+            s"""{"maxReceiveCount":"3", "deadLetterTargetArn":"${dlq.arn}"}"""
         )
 
         testWith(QueuePair(queue, dlq))
@@ -166,8 +171,7 @@ trait SQS extends Matchers with Logging {
   def withSQSStream[T, R](
     queue: Queue,
     metrics: Metrics[Future, StandardUnit] = new MemoryMetrics[StandardUnit]()
-  )(
-    testWith: TestWith[SQSStream[T], R])(
+  )(testWith: TestWith[SQSStream[T], R])(
     implicit actorSystem: ActorSystem): R = {
     val sqsConfig = createSQSConfigWith(queue)
 

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/fixtures/SQS.scala
@@ -250,17 +250,6 @@ trait SQS extends Matchers with Logging {
     noMessagesAreWaitingIn(queue)
   }
 
-  def assertQueueNotEmpty(queue: Queue): Assertion = {
-    waitVisibilityTimeoutExpiry(queue)
-
-    val messages = getMessages(queue)
-
-    assert(
-      messages.nonEmpty,
-      s"Expected ${queue.url} to have messages, but was actually empty"
-    )
-  }
-
   def assertQueueHasSize(queue: Queue, size: Int): Assertion = {
     waitVisibilityTimeoutExpiry(queue)
 

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/fixtures/SQS.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/fixtures/SQS.scala
@@ -161,7 +161,10 @@ trait SQS extends Matchers with Logging {
       testWith(queue)
     }
 
-  def withSQSStream[T, R](queue: Queue, metrics: Metrics[Future, StandardUnit])(
+  def withSQSStream[T, R](
+    queue: Queue,
+    metrics: Metrics[Future, StandardUnit] = new MemoryMetrics[StandardUnit]()
+  )(
     testWith: TestWith[SQSStream[T], R])(
     implicit actorSystem: ActorSystem): R = {
     val sqsConfig = createSQSConfigWith(queue)
@@ -173,14 +176,6 @@ trait SQS extends Matchers with Logging {
     )
 
     testWith(stream)
-  }
-
-  def withSQSStream[T, R](queue: Queue)(testWith: TestWith[SQSStream[T], R])(
-    implicit actorSystem: ActorSystem): R = {
-    val metrics = new MemoryMetrics[StandardUnit]()
-    withSQSStream[T, R](queue, metrics) { sqsStream =>
-      testWith(sqsStream)
-    }
   }
 
   def createNotificationMessageWith(body: String): NotificationMessage =

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/sqs/SQSStreamTest.scala
@@ -257,7 +257,7 @@ class SQSStreamTest
                         MemoryMetrics[StandardUnit]),
                        R]): R =
     withActorSystem { implicit actorSystem =>
-      withLocalSqsQueueAndDlq {
+      withLocalSqsQueuePair() {
         case queuePair @ QueuePair(queue, _) =>
           val metrics = new MemoryMetrics[StandardUnit]()
           withSQSStream[NamedObject, R](queue, metrics) { stream =>

--- a/messaging/src/test/scala/uk/ac/wellcome/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
+++ b/messaging/src/test/scala/uk/ac/wellcome/messaging/sqsworker/alpakka/AlpakkaSQSWorkerTest.scala
@@ -23,7 +23,7 @@ class AlpakkaSQSWorkerTest
 
   describe("When a message is processed") {
     it("consumes a message and increments success metrics") {
-      withLocalSqsQueueAndDlq {
+      withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
           withActorSystem { implicit actorSystem =>
             withAlpakkaSQSWorker(queue, successful, namespace) {
@@ -58,7 +58,7 @@ class AlpakkaSQSWorkerTest
 
     it(
       "consumes a message and increments non deterministic failure metrics metrics") {
-      withLocalSqsQueueAndDlq {
+      withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
           withActorSystem { implicit actorSystem =>
             withAlpakkaSQSWorker(queue, deterministicFailure, namespace) {
@@ -93,7 +93,7 @@ class AlpakkaSQSWorkerTest
 
     it(
       "retries nonDeterministicFailure 3 times and places the message in the dlq") {
-      withLocalSqsQueueAndDlq {
+      withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
           withActorSystem { implicit actorSystem =>
             withAlpakkaSQSWorker(queue, nonDeterministicFailure, namespace) {
@@ -130,7 +130,7 @@ class AlpakkaSQSWorkerTest
   describe("When a message cannot be parsed") {
     it(
       "consumes the message increments failure metrics if the message is not json") {
-      withLocalSqsQueueAndDlq {
+      withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
           withActorSystem { implicit actorSystem =>
             withAlpakkaSQSWorker(queue, successful, namespace) {
@@ -164,7 +164,7 @@ class AlpakkaSQSWorkerTest
 
     it(
       "consumes the message increments failure metrics if the message is json but not a work") {
-      withLocalSqsQueueAndDlq {
+      withLocalSqsQueuePair() {
         case QueuePair(queue, dlq) =>
           withActorSystem { implicit actorSystem =>
             withAlpakkaSQSWorker(queue, successful, namespace) {


### PR DESCRIPTION
* Allow setting the visibility timeout on an individual queue
* Label the DLQ of a queue as `$queueName-dlq`, for easier debugging
* Remove some helpers that we weren't using